### PR TITLE
build(deps): bump rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "infer",
  "magnus",
  "reqwest",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "wasmtime",
@@ -2062,15 +2063,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/ext/app_bridge/Cargo.toml
+++ b/ext/app_bridge/Cargo.toml
@@ -20,6 +20,7 @@ base64 = "0.22"
 infer = "0.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rustls-webpki = "0.103.13"
 
 [dev-dependencies]
 httpmock = "0.8.2"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the Rust `app_bridge` crate; main impact is TLS certificate verification behavior from updated `rustls-webpki`/`rustls-pki-types`. Potential risk is subtle runtime compatibility changes in TLS handling.
> 
> **Overview**
> Updates the Rust `app_bridge` crate to depend explicitly on `rustls-webpki` `0.103.13`.
> 
> Regenerates `Cargo.lock` to bump `rustls-webpki` (and `rustls-pki-types` to `1.14.1`, adding `zeroize`) to the new versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ba7b150646706734a3f07b0661256d006e4a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->