### PR TITLE
build(deps): bump rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,9 +1765,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency lockfile-only change with no direct code modifications in this PR.
> 
> **Overview**
> Updates the locked **`rand`** crate from **0.8.5** to **0.8.6** in `Cargo.lock` (checksum updated accordingly). No application source or manifest changes appear in this diff—only the transitive dependency pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4302e81ee1ab793b261a9350d70739b1bc6b34fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->